### PR TITLE
Fix invalid link to migration

### DIFF
--- a/doc/migration-from-ida.md
+++ b/doc/migration-from-ida.md
@@ -1,4 +1,4 @@
 Migration from IDA to Radare2
 =============================
 
-https://github.com/radare/radare2/wiki/Migration-from-ida-or-gdb
+https://radare.gitbooks.io/radare2book/content/debugger/migration.html


### PR DESCRIPTION
Old wiki was moved to radare2book